### PR TITLE
Fix leaderboard period handling and adjust cron anchor

### DIFF
--- a/api/cron/refresh-leaderboard.ts
+++ b/api/cron/refresh-leaderboard.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { ensureSchema, upsertEntry } from '../../lib/db';
 function currentMonthRange() {
   // Anchor start of cycle (adjust if needed):
-  const anchorStartUTC = Date.UTC(2025, 8, 29, 0, 0, 0); // Aug 26, 2025 (month is 0-based)
+  const anchorStartUTC = Date.UTC(2025, 7, 29, 0, 0, 0); // Aug 29, 2025 (month is 0-based)
   const PERIOD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
   const now = new Date();

--- a/api/leaderboard/top.ts
+++ b/api/leaderboard/top.ts
@@ -1,6 +1,6 @@
 // api/leaderboard/top.ts
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { ensureSchema, getTop15ForCurrentMonth } from '../../lib/db';
+import { ensureSchema, getTop15ForCurrentPeriod } from '../../lib/db';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // --- CORS (must be INSIDE the handler) ---
@@ -15,7 +15,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     await ensureSchema(); // ensure table exists
-    const rows = await getTop15ForCurrentMonth();
+    const rows = await getTop15ForCurrentPeriod();
 
     // 60s edge cache (optional)
     res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=600');

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -47,14 +47,12 @@ export async function upsertEntry(row: {
   `;
 }
 
-export async function getTop15ForCurrentMonth() {
-  const now = new Date();
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0));
-  const end   = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
+export async function getTop15ForCurrentPeriod() {
+  const now = new Date().toISOString();
   const rows = await sql/* sql */`
     SELECT username, (wagered)::float AS wagered, rank
     FROM leaderboard_entries
-    WHERE period_start = ${start.toISOString()} AND period_end = ${end.toISOString()}
+    WHERE period_start <= ${now} AND period_end > ${now}
     ORDER BY rank ASC
     LIMIT 15
   `;


### PR DESCRIPTION
## Summary
- rename leaderboard getter to `getTop15ForCurrentPeriod`
- update API to use new name
- adjust cron anchor month to August

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b64fa860833293b4317bfea51cd3