### PR TITLE
Add leaderboard history view and adjust period anchor

### DIFF
--- a/api/cron/refresh-leaderboard.ts
+++ b/api/cron/refresh-leaderboard.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { ensureSchema, upsertEntry } from '../../lib/db';
 function currentMonthRange() {
   // Anchor start of cycle (adjust if needed):
-  const anchorStartUTC = Date.UTC(2025, 7, 29, 0, 0, 0); // Aug 29, 2025 (month is 0-based)
+  const anchorStartUTC = Date.UTC(2025, 7, 26, 0, 0, 0); // Aug 26, 2025 (month is 0-based)
   const PERIOD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
   const now = new Date();

--- a/api/leaderboard/previous.ts
+++ b/api/leaderboard/previous.ts
@@ -1,0 +1,27 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { ensureSchema, getTop15ForPreviousPeriod } from '../../lib/db';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // --- CORS (must be INSIDE the handler) ---
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    await ensureSchema();
+    const { period_start, period_end, rows } = await getTop15ForPreviousPeriod();
+
+    // 60s edge cache (optional)
+    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=600');
+
+    return res.status(200).json({ period_start, period_end, items: rows });
+  } catch (e: any) {
+    console.error('leaderboard/previous error:', e);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -58,3 +58,24 @@ export async function getTop15ForCurrentPeriod() {
   `;
   return rows; // array of rows
 }
+
+export async function getTop15ForPreviousPeriod() {
+  const now = new Date().toISOString();
+  const period = await sql/* sql */`
+    SELECT period_start, period_end
+    FROM leaderboard_entries
+    WHERE period_end <= ${now}
+    ORDER BY period_end DESC
+    LIMIT 1
+  `;
+  if (period.length === 0) return { period_start: null, period_end: null, rows: [] };
+  const { period_start, period_end } = period[0] as { period_start: string; period_end: string };
+  const rows = await sql/* sql */`
+    SELECT username, (wagered)::float AS wagered, rank
+    FROM leaderboard_entries
+    WHERE period_start = ${period_start} AND period_end = ${period_end}
+    ORDER BY rank ASC
+    LIMIT 15
+  `;
+  return { period_start, period_end, rows };
+}


### PR DESCRIPTION
## Summary
- shift leaderboard period anchor to Aug 26, 2025
- expose previous-period standings via new endpoint and DB query
- add history toggle on leaderboard page with HistoryTable for prior results

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ba895fd48332990722551ccd298e