### PR TITLE
fix: remove duplicate historyRows state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -473,7 +473,8 @@ function LeaderboardsPage() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState("");
   const [showHistory, setShowHistory] = React.useState(false);
-  const [historyRows, setHistoryRows] = React.useState([]);
+  // store previously fetched leaderboard entries
+  const [historyData, setHistoryData] = React.useState([]);
   const [historyRange, setHistoryRange] = React.useState({ start: "", end: "" });
   const [historyLoading, setHistoryLoading] = React.useState(true);
 
@@ -545,12 +546,12 @@ function LeaderboardsPage() {
           prize: prizeByRank[x.rank] ?? 0,
         }));
         if (!alive) return;
-        setHistoryRows(items);
+        setHistoryData(items);
         setHistoryRange({ start: j.period_start, end: j.period_end });
       } catch (e) {
         if (!alive) return;
         console.error(e);
-        setHistoryRows([]);
+        setHistoryData([]);
         setHistoryRange({ start: "", end: "" });
       } finally {
         if (alive) setHistoryLoading(false);
@@ -599,7 +600,7 @@ function LeaderboardsPage() {
             </header>
 
             {showHistory ? (
-              <HistoryTable rows={historyRows} range={historyRange} loading={historyLoading} />
+              <HistoryTable rows={historyData} range={historyRange} loading={historyLoading} />
             ) : (
               <>
                 {/* Podium (exact 2 / 1 / 3 layout preserved) */}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// jsdom doesn't implement canvas; mock getContext to avoid errors
+HTMLCanvasElement.prototype.getContext = () => {};
+
+test('renders LuckyW brand', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getAllByText(/LuckyW/i).length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- avoid redeclaring `historyRows` state by renaming to `historyData`
- update tests to mock canvas and check for LuckyW brand

## Testing
- `npm run build`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1bf9b54a8833289eb4c4c6a517d7a