### PR TITLE
feat: add leaderboard history save API and modal

### DIFF
--- a/api/leaderboard/save.ts
+++ b/api/leaderboard/save.ts
@@ -1,0 +1,42 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { ensureSchema, upsertEntry } from '../../lib/db';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // --- CORS handling ---
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const { period_start, period_end, items } = req.body || {};
+    if (!period_start || !period_end || !Array.isArray(items)) {
+      return res.status(400).json({ error: 'Invalid body' });
+    }
+
+    await ensureSchema();
+
+    let saved = 0;
+    for (const entry of items) {
+      if (!entry || !entry.uid) continue;
+      await upsertEntry({
+        period_start,
+        period_end,
+        uid: entry.uid,
+        username: entry.username || '',
+        wagered: Number(entry.wagered || 0),
+        rank: Number(entry.rank || 0),
+      });
+      saved++;
+    }
+
+    return res.status(200).json({ ok: true, saved });
+  } catch (e: any) {
+    console.error('leaderboard/save error:', e);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -591,20 +591,16 @@ function LeaderboardsPage() {
                 Monthly Leaderboard
               </h1>
               <button
-                onClick={() => setShowHistory((h) => !h)}
+                onClick={() => setShowHistory(true)}
                 className="text-xs px-3 py-1 rounded border"
                 style={{ borderColor: KICK_GREEN, color: KICK_GREEN }}
               >
-                {showHistory ? 'Back' : 'History'}
+                History
               </button>
             </header>
 
-            {showHistory ? (
-              <HistoryTable rows={historyData} range={historyRange} loading={historyLoading} />
-            ) : (
-              <>
-                {/* Podium (exact 2 / 1 / 3 layout preserved) */}
-                <div className="grid md:grid-cols-3 gap-4 md:gap-6 mb-4">
+            {/* Podium (exact 2 / 1 / 3 layout preserved) */}
+            <div className="grid md:grid-cols-3 gap-4 md:gap-6 mb-4">
               {top3[1] && (
                 <PodiumCard
                   placement={2}
@@ -693,10 +689,17 @@ function LeaderboardsPage() {
                 )}
               </div>
             </div>
+
+            {showHistory && (
+              <HistoryModal
+                rows={historyData}
+                range={historyRange}
+                loading={historyLoading}
+                onClose={() => setShowHistory(false)}
+              />
+            )}
           </>
         )}
-      </>
-    )}
       </div>
     </section>
   );
@@ -797,6 +800,22 @@ function HistoryTable({ rows, range, loading }) {
           {formatPeriod(range.start, range.end)}
         </div>
       )}
+    </div>
+  );
+}
+
+function HistoryModal({ rows, range, loading, onClose }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="relative w-full max-w-2xl">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-sm px-2 py-1 rounded bg-black/60 border border-white/20"
+        >
+          Close
+        </button>
+        <HistoryTable rows={rows} range={range} loading={loading} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add POST endpoint to persist leaderboard entries
- show leaderboard history inside modal instead of page swap

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c1c23749008332982965586ce441eb