### PR TITLE
Fetch previous leaderboard and mask usernames

### DIFF
--- a/api/cron/refresh-leaderboard.ts
+++ b/api/cron/refresh-leaderboard.ts
@@ -1,12 +1,14 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { ensureSchema, upsertEntry } from '../../lib/db';
-function currentMonthRange() {
-  // Anchor start of cycle (adjust if needed):
+
+// Determine the current and previous 14-day periods
+function getPeriods() {
+  // Anchor start of cycle (adjust if needed)
   const anchorStartUTC = Date.UTC(2025, 7, 26, 0, 0, 0); // Aug 26, 2025 (month is 0-based)
   const PERIOD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
   const now = new Date();
-  // Use *midnight UTC* to avoid timezone drift
+  // Use midnight UTC to avoid timezone drift
   const nowMidnightUTC = Date.UTC(
     now.getUTCFullYear(),
     now.getUTCMonth(),
@@ -17,14 +19,22 @@ function currentMonthRange() {
   // Which 14-day bucket are we in?
   const k = Math.floor((nowMidnightUTC - anchorStartUTC) / PERIOD_MS);
 
-  const startMs = anchorStartUTC + k * PERIOD_MS;     // inclusive
-  const endMs   = startMs + PERIOD_MS;                // exclusive ("until")
+  const currentStartMs = anchorStartUTC + k * PERIOD_MS; // inclusive
+  const currentEndMs = currentStartMs + PERIOD_MS; // exclusive
 
-  const start = new Date(startMs);
-  const end   = new Date(endMs);
+  const previousStartMs = currentStartMs - PERIOD_MS;
+  const previousEndMs = currentStartMs;
 
-  console.log("Fetching stats between:", start.toISOString(), "and", end.toISOString());
-  return { startISO: start.toISOString(), endISO: end.toISOString() };
+  return {
+    current: {
+      startISO: new Date(currentStartMs).toISOString(),
+      endISO: new Date(currentEndMs).toISOString(),
+    },
+    previous: {
+      startISO: new Date(previousStartMs).toISOString(),
+      endISO: new Date(previousEndMs).toISOString(),
+    },
+  };
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -38,42 +48,48 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const userId = process.env.ROOBET_USER_ID!;
     if (!base || !token || !userId) throw new Error('Missing env vars');
 
-    const { startISO, endISO } = currentMonthRange();
+    const { current, previous } = getPeriods();
 
-    const url = new URL('/affiliate/v2/stats', base);
-    url.searchParams.set('userId', userId);
-    url.searchParams.set('startDate', startISO);
-    url.searchParams.set('endDate', endISO);
+    async function fetchAndSave(range: { startISO: string; endISO: string }) {
+      const url = new URL('/affiliate/v2/stats', base);
+      url.searchParams.set('userId', userId);
+      url.searchParams.set('startDate', range.startISO);
+      url.searchParams.set('endDate', range.endISO);
 
-    const r = await fetch(url.toString(), {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-
-    if (!r.ok) {
-      const t = await r.text();
-      return res.status(502).json({ error: `Upstream error: ${t}` });
-    }
-
-    const data: Array<{ uid: string; username: string; wagered: number }> = await r.json();
-
-    const top = (data ?? [])
-      .sort((a, b) => b.wagered - a.wagered)
-      .slice(0, 15);
-
-    let rank = 1;
-    for (const row of top) {
-      await upsertEntry({
-        period_start: startISO,
-        period_end: endISO,
-        uid: row.uid,
-        username: row.username,
-        wagered: Number(row.wagered || 0),
-        rank,
+      const r = await fetch(url.toString(), {
+        headers: { Authorization: `Bearer ${token}` },
       });
-      rank++;
+
+      if (!r.ok) {
+        const t = await r.text();
+        throw new Error(`Upstream error: ${t}`);
+      }
+
+      const data: Array<{ uid: string; username: string; wagered: number }> = await r.json();
+
+      const top = (data ?? [])
+        .sort((a, b) => b.wagered - a.wagered)
+        .slice(0, 15);
+
+      let rank = 1;
+      for (const row of top) {
+        await upsertEntry({
+          period_start: range.startISO,
+          period_end: range.endISO,
+          uid: row.uid,
+          username: row.username,
+          wagered: Number(row.wagered || 0),
+          rank,
+        });
+        rank++;
+      }
+      return top.length;
     }
 
-    return res.status(200).json({ ok: true, saved: top.length });
+    const savedCurrent = await fetchAndSave(current);
+    const savedPrevious = await fetchAndSave(previous);
+
+    return res.status(200).json({ ok: true, savedCurrent, savedPrevious });
   } catch (e: any) {
     console.error(e);
     return res.status(500).json({ error: 'Internal Server Error' });

--- a/src/App.js
+++ b/src/App.js
@@ -677,7 +677,7 @@ function LeaderboardsPage() {
                 {rest.map((r) => (
                   <div key={r.rank} className="grid grid-cols-12 items-center px-3 py-3 hover:bg-white/[0.02]">
                     <div className="col-span-2 font-black text-white">#{r.rank}</div>
-                    <div className="col-span-5">{r.name}</div>
+                    <div className="col-span-5">{maskName(r.name)}</div>
                     <div className="col-span-3 text-gray-300">{formatMoney(r.wagered)}</div>
                     <div className="col-span-2 text-right font-semibold" style={{ color: KICK_GREEN }}>
                       {formatMoney(r.prize)}
@@ -736,7 +736,7 @@ function PodiumCard({ placement, item, className, height, tint, edgeColor, badge
         <div className="flex items-end justify-between">
           <div>
             <div className="text-5xl font-black" style={{ color: highlight ? KICK_GREEN : "white" }}>#{item.rank}</div>
-            <div className="text-lg font-semibold">{item.name}</div>
+            <div className="text-lg font-semibold">{maskName(item.name)}</div>
           </div>
           <div className="text-right">
             <div className="text-xs text-gray-400">Wagered</div>
@@ -784,7 +784,7 @@ function HistoryTable({ rows, range, loading }) {
         {rows.map((r) => (
           <div key={r.rank} className="grid grid-cols-12 items-center px-3 py-3 hover:bg-white/[0.02]">
             <div className="col-span-2 font-black text-white">#{r.rank}</div>
-            <div className="col-span-5">{r.name}</div>
+            <div className="col-span-5">{maskName(r.name)}</div>
             <div className="col-span-3 text-gray-300">{formatMoney(r.wagered)}</div>
             <div className="col-span-2 text-right font-semibold" style={{ color: KICK_GREEN }}>
               {formatMoney(r.prize)}
@@ -858,6 +858,14 @@ function useMonthEndCountdown() {
   return { days: d, hours: h, minutes: m, seconds: s };
 }
 
+// Obfuscate a username so only first two characters are visible
+function maskName(name) {
+  if (!name) return "";
+  const visible = name.slice(0, 2);
+  const hidden = "*".repeat(Math.max(name.length - 2, 0));
+  return visible + hidden;
+}
+
 function formatMoney(n) {
   const isIntPrize = Number.isInteger(n);
   const value = isIntPrize ? n : Math.round(n * 100) / 100;
@@ -897,7 +905,7 @@ function LeaderboardPreview() {
         {rows.map((r) => (
           <div key={r.rank} className="grid grid-cols-12 items-center px-3 py-3">
             <div className="col-span-2 font-black" style={{ color: r.rank <= 3 ? KICK_GREEN : "white" }}>#{r.rank}</div>
-            <div className="col-span-5">{r.user}</div>
+            <div className="col-span-5">{maskName(r.user)}</div>
             <div className="col-span-3 text-gray-300">{r.points.toLocaleString()}</div>
             <div className="col-span-2 text-right font-semibold">{r.prize}</div>
           </div>

--- a/src/leaderboardactual.js
+++ b/src/leaderboardactual.js
@@ -85,7 +85,7 @@ export default function LeaderboardPage() {
               {rest.map((r) => (
                 <div key={r.rank} className="grid grid-cols-12 px-5 py-3 items-center hover:bg-white/[0.02]">
                   <div className="col-span-2 font-bold text-gray-200">#{r.rank}</div>
-                  <div className="col-span-5 font-medium">{r.name}</div>
+                  <div className="col-span-5 font-medium">{maskName(r.name)}</div>
                   <div className="col-span-3 text-gray-300">{formatMoney(r.wagered)}</div>
                   <div className="col-span-2 text-right font-semibold" style={{color:KICK_GREEN}}>{formatMoney(r.prize)}</div>
                 </div>
@@ -187,7 +187,7 @@ function PodiumCard({ placement, item, className, height, tint, edgeColor, badge
         <div className="flex items-end justify-between">
           <div>
             <div className="text-5xl font-black" style={{ color: highlight ? KICK_GREEN : "white" }}>#{item.rank}</div>
-            <div className="text-lg font-semibold">{item.name}</div>
+            <div className="text-lg font-semibold">{maskName(item.name)}</div>
           </div>
           <div className="text-right">
             <div className="text-xs text-gray-400">Wagered</div>
@@ -252,6 +252,13 @@ function useMonthEndCountdown(){
 }
 
 // ——— Utils ———
+function maskName(name){
+  if(!name) return "";
+  const visible = name.slice(0,2);
+  const hidden = "*".repeat(Math.max(name.length - 2, 0));
+  return visible + hidden;
+}
+
 function formatMoney(n){
   const isIntPrize = Number.isInteger(n);
   const value = isIntPrize ? n : Math.round(n*100)/100;


### PR DESCRIPTION
## Summary
- refresh-leaderboard cron now saves both current and previous 14-day periods
- obfuscate usernames to show first two letters only across leaderboard UIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c5b393ac8332a3dc40559b57600b