### PR TITLE
feat: add discord logo and prioritize leaderboards

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,21 @@ import useLeaderboardCountdown from "./useLeaderboardCountdown";
 // —— Brand Tokens ——
 const KICK_GREEN = "#00e701"; // exact green
 
+function DiscordIcon({ size = 24, ...props }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2496-1.8447-.2763-3.68-.2763-5.4868 0-.1636-.4008-.4058-.8743-.6177-1.2496a.076.076 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.5153.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0536 1.5073 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8926a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0742.0742 0 01.0776-.0105c3.9276 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0096c.1202.099.246.1981.372.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.8732.8916.0766.0766 0 00-.0406.1067c.3608.698.7723 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9487-1.5222 6.0023-3.0294a.077.077 0 00.0312-.0551c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0285zM8.02 15.3312c-1.1825 0-2.1569-1.0847-2.1569-2.419 0-1.3344.9555-2.4189 2.157-2.4189 1.2104 0 2.1757 1.0962 2.1568 2.4189 0 1.3343-.9555 2.419-2.1569 2.419zm7.9748 0c-1.1825 0-2.1569-1.0847-2.1569-2.419 0-1.3344.9554-2.4189 2.1569-2.4189 1.2104 0 2.1758 1.0962 2.1569 2.4189 0 1.3343-.9465 2.419-2.1569 2.419Z" />
+    </svg>
+  );
+}
+
 // —— Very light hash-based router (no extra deps) ——
 function useHashRoute() {
   const [path, setPath] = useState(() => window.location.hash.replace("#", "") || "/");
@@ -151,8 +166,8 @@ function Navbar() {
         </div>
         <ul className="hidden md:flex items-center gap-8 text-sm md:text-base text-gray-300">
           <li>{link("/", "Home")}</li>
-          <li>{link("/bonuses", "Bonuses")}</li>
           <li>{link("/leaderboards", "Leaderboards")}</li>
+          <li>{link("/bonuses", "Bonuses")}</li>
           <li>{link("/rules", "Rules")}</li>
         </ul>
         <div className="hidden md:flex items-center gap-4 text-gray-300">
@@ -163,7 +178,7 @@ function Navbar() {
             aria-label="Discord"
             className="hover:text-white"
           >
-            <MessageCircle size={20} />
+            <DiscordIcon size={20} />
           </a>
           <a
             href="https://www.instagram.com/kickluckyw?igsh=MWF0bTBzbXMxYjM4aA%3D%3D&utm_source=qr"
@@ -182,8 +197,8 @@ function Navbar() {
       {open && (
         <div className="md:hidden mx-auto max-w-7xl px-6 py-3 grid gap-2 text-gray-200">
           {link("/", "Home")}
-          {link("/bonuses", "Bonuses")}
           {link("/leaderboards", "Leaderboards")}
+          {link("/bonuses", "Bonuses")}
           {link("/rules", "Rules")}
           <div className="flex gap-4 pt-2 text-gray-300">
             <a
@@ -193,7 +208,7 @@ function Navbar() {
               aria-label="Discord"
               className="hover:text-white"
             >
-              <MessageCircle size={20} />
+              <DiscordIcon size={20} />
             </a>
             <a
               href="https://www.instagram.com/kickluckyw?igsh=MWF0bTBzbXMxYjM4aA%3D%3D&utm_source=qr"
@@ -223,8 +238,8 @@ function Footer() {
           title="Pages"
           links={[
             { label: "Home", href: "#/" },
-            { label: "Bonuses", href: "#/bonuses" },
             { label: "Leaderboards", href: "#/leaderboards" },
+            { label: "Bonuses", href: "#/bonuses" },
             { label: "Rules", href: "#/rules" },
           ]}
         />
@@ -328,12 +343,12 @@ function HomePage() {
 
           {/* CTAs */}
           <motion.div className="flex flex-col sm:flex-row justify-center gap-4 md:gap-6" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2, duration: 0.8 }}>
-            <a href="#/bonuses" className="relative overflow-hidden px-8 py-4 text-base md:text-lg rounded-2xl font-semibold inline-flex items-center justify-center" style={{ backgroundColor: KICK_GREEN, color: "#0a0a0a", boxShadow: "0 10px 35px rgba(0,231,1,0.35)" }}>
-              <Gift className="mr-2" size={20} /> Bonuses
-            </a>
             <a href="#/leaderboards" className="relative group px-8 py-4 text-base md:text-lg rounded-2xl font-semibold inline-flex items-center justify-center" style={{ border: `2px solid ${KICK_GREEN}`, boxShadow: "0 8px 30px rgba(0,231,1,0.18)" }}>
               <span className="relative z-10" style={{ color: KICK_GREEN }}><Trophy className="inline mr-2" size={20}/>Leaderboards</span>
               <span className="absolute inset-0 rounded-2xl -z-0 scale-x-0 origin-left group-hover:scale-x-100 transition-transform duration-300" style={{ backgroundColor: "rgba(0,231,1,0.12)" }} />
+            </a>
+            <a href="#/bonuses" className="relative overflow-hidden px-8 py-4 text-base md:text-lg rounded-2xl font-semibold inline-flex items-center justify-center" style={{ backgroundColor: KICK_GREEN, color: "#0a0a0a", boxShadow: "0 10px 35px rgba(0,231,1,0.35)" }}>
+              <Gift className="mr-2" size={20} /> Bonuses
             </a>
           </motion.div>
 


### PR DESCRIPTION
## Summary
- swap bonuses link with leaderboards so leaderboards appear first
- show official Discord icon in navbar social links

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c43379da6083328e2f1ed719cb3597